### PR TITLE
add fontWeight property

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ myScene.add(myText);
 | <b>color</b> | The color of the text. | `white` |
 | <b>fontFace</b> | The font type of the text. | `Arial` |
 | <b>fontSize</b> | The resolution of the text, in terms of vertical number of pixels. Lower values may cause text to look blurry. Higher values will yield sharper text, at the cost of performance. | `90` |
+| <b>fontWeight</b> | The weight (or boldness) of the font. The weights available depend on the font-family you are using. | `normal` |
 
 ## Giving Back
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ export default class extends three.Sprite {
 
     this._fontFace = 'Arial';
     this._fontSize = 90; // defines text resolution
+    this._fontWeight = 'normal';
 
     this._canvas = document.createElement('canvas');
     this._texture = this.material.map;
@@ -42,12 +43,14 @@ export default class extends three.Sprite {
   set fontFace(fontFace) { this._fontFace = fontFace; this._genCanvas(); }
   get fontSize() { return this._fontSize; }
   set fontSize(fontSize) { this._fontSize = fontSize; this._genCanvas(); }
+  get fontWeight() { return this._fontWeight; }
+  set fontWeight(fontWeight) { this._fontWeight = fontWeight; this._genCanvas(); }
 
   _genCanvas() {
     const canvas = this._canvas;
     const ctx = canvas.getContext('2d');
 
-    const font = `normal ${this.fontSize}px ${this.fontFace}`;
+    const font = `${this.fontWeight} ${this.fontSize}px ${this.fontFace}`;
 
     ctx.font = font;
     const textWidth = ctx.measureText(this.text).width;
@@ -76,6 +79,7 @@ export default class extends three.Sprite {
     this.color = source.color;
     this.fontFace = source.fontFace;
     this.fontSize = source.fontSize;
+    this.fontWeight = source.fontWeight;
 
     return this;
   }


### PR DESCRIPTION
To use spritetext with custom fonts (like font awesome), that need a specific font weight to be set, otherwise they won't render.