### PR TITLE
Multiline support

### DIFF
--- a/example/multiline/index.html
+++ b/example/multiline/index.html
@@ -1,0 +1,45 @@
+<head>
+  <style> body { margin: 0; } </style>
+
+  <script src="//unpkg.com/three"></script>
+  <script src="//unpkg.com/three-trackballcontrols-web/dist/three-trackballcontrols.min.js"></script>
+  <!--<script src="//unpkg.com/three-spritetext"></script>-->
+  <script src="../../dist/three-spritetext.js"></script>
+</head>
+
+<body>
+  <div id="container"></div>
+
+  <script>
+    const Text = new SpriteText('This is\nsome multi-line\ntext', 10);
+    Text.color = 'orange';
+
+    // Setup renderer
+    const renderer = new THREE.WebGLRenderer();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    document.getElementById('container').appendChild(renderer.domElement);
+
+    // Setup scene
+    const scene = new THREE.Scene();
+    scene.add(Text);
+    scene.add(new THREE.AmbientLight(0xbbbbbb));
+
+    // Setup camera
+    const camera = new THREE.PerspectiveCamera();
+    camera.aspect = window.innerWidth/window.innerHeight;
+    camera.updateProjectionMatrix();
+    camera.lookAt(0, 0, 0);
+    camera.position.z = 100;
+
+    // Add camera controls
+    const tbControls = new TrackballControls(camera, renderer.domElement);
+
+    // Kick-off renderer
+    (function animate() { // IIFE
+      // Frame cycle
+      tbControls.update();
+      renderer.render(scene, camera);
+      requestAnimationFrame(animate);
+    })();
+  </script>
+</body>

--- a/src/index.js
+++ b/src/index.js
@@ -53,14 +53,19 @@ export default class extends three.Sprite {
     const font = `${this.fontWeight} ${this.fontSize}px ${this.fontFace}`;
 
     ctx.font = font;
-    const textWidth = ctx.measureText(this.text).width;
+	
+	var lines = this._text.split('\n');
+	var textWidth = Math.max(...lines.map(function (line) { return ctx.measureText(line).width; }));
+	
     canvas.width = textWidth;
-    canvas.height = this.fontSize;
+    canvas.height = this.fontSize * lines.length;
 
     ctx.font = font;
     ctx.fillStyle = this.color;
     ctx.textBaseline = 'bottom';
-    ctx.fillText(this.text, 0, canvas.height);
+	
+	for (var i = 0; i<lines.length; i++)
+		ctx.fillText(lines[i], 0, (i + 1) * this.fontSize );
 
     // Inject canvas into sprite
     this._texture.image = canvas;

--- a/src/index.js
+++ b/src/index.js
@@ -54,8 +54,8 @@ export default class extends three.Sprite {
 
     ctx.font = font;
 	
-	var lines = this._text.split('\n');
-	var textWidth = Math.max(...lines.map(function (line) { return ctx.measureText(line).width; }));
+	const  lines = this._text.split('\n');
+	const  textWidth = Math.max(...lines.map(function (line) { return ctx.measureText(line).width; }));
 	
     canvas.width = textWidth;
     canvas.height = this.fontSize * lines.length;
@@ -64,8 +64,7 @@ export default class extends three.Sprite {
     ctx.fillStyle = this.color;
     ctx.textBaseline = 'bottom';
 	
-	for (var i = 0; i<lines.length; i++)
-		ctx.fillText(lines[i], (canvas.width - ctx.measureText(lines[i]).width) / 2, (i + 1) * this.fontSize );
+	lines.forEach((line, index) => ctx.fillText(line, (canvas.width - ctx.measureText(line).width) / 2, (index + 1) * this.fontSize ));
 
     // Inject canvas into sprite
     this._texture.image = canvas;

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export default class extends three.Sprite {
     ctx.textBaseline = 'bottom';
 	
 	for (var i = 0; i<lines.length; i++)
-		ctx.fillText(lines[i], 0, (i + 1) * this.fontSize );
+		ctx.fillText(lines[i], (canvas.width - ctx.measureText(lines[i]).width) / 2, (i + 1) * this.fontSize );
 
     // Inject canvas into sprite
     this._texture.image = canvas;


### PR DESCRIPTION
Commits 1-3 (1da892f - 8b86e24):
- adding docker support with express server for quick run (without any development environment)
- adding multi-line text example page

Commit 4-5 (36af266 -0fe4237) adding multi-line centered text support.

The 5th commit may be used as a base for signature extension allowing to specify alignment.

I use multi-line text in 3d-force-graph displaying 2 line text nodes.
