### PR TITLE
Set context font again, before drawing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,10 +51,6 @@ export default class extends three.Sprite {
     const ctx = canvas.getContext('2d');
   
     const lines = this._text.split('\n');
-
-    canvas.width = Math.max(...lines.map(line => ctx.measureText(line).width));
-    canvas.height = this.fontSize * lines.length;
-
     const font = `${this.fontWeight} ${this.fontSize}px ${this.fontFace}`;
   
     //Measure actual font.

--- a/src/index.js
+++ b/src/index.js
@@ -55,10 +55,18 @@ export default class extends three.Sprite {
     canvas.width = Math.max(...lines.map(line => ctx.measureText(line).width));
     canvas.height = this.fontSize * lines.length;
 
-    ctx.font = `${this.fontWeight} ${this.fontSize}px ${this.fontFace}`;
+    const font = `${this.fontWeight} ${this.fontSize}px ${this.fontFace}`;
+  
+    //Measure actual font.
+    ctx.font = font;
+    canvas.width = Math.max(...lines.map(line => ctx.measureText(line).width));
+    canvas.height = this.fontSize * lines.length;
+
+    //After canvas is modified (see size settings above), context has all properties reset, thus setting font again.
+    ctx.font = font;
     ctx.fillStyle = this.color;
     ctx.textBaseline = 'bottom';
-  
+
     lines.forEach((line, index) => ctx.fillText(
       line,
       (canvas.width - ctx.measureText(line).width) / 2,


### PR DESCRIPTION
The context is reset as the result of [canvas size modification](https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-set-bitmap-dimensions).
This was the behavior before multiline feature. I've added comments in case someone in the future will think this resetting is useless. :)