### PR TITLE
Add missing borderRadius property to index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -25,6 +25,8 @@ declare class SpriteText extends Sprite {
   set padding(fontSize: number);
   get borderWidth(): number;
   set borderWidth(fontSize: number);
+  get borderRadius(): number;
+  set borderRadius(radius: number);
   get borderColor(): string;
   set borderColor(color:string);
   get strokeWidth(): number;


### PR DESCRIPTION
I noticed in my typescript-based project that the borderRadius property was unknown. Adding this to index.d.ts fixes the problem.